### PR TITLE
GH Action for Automated Publishing

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -21,18 +21,11 @@ jobs:
       - name: Install dependencies
         run: |
           pip install mkdocs mkdocs-material
-          pip install markdown-extensions pymdown-extensions
-
+          pip install mkdocs-techdocs-core
+          pip install mkdocs-include-markdown-plugin
       - name: Deploy docs
         run: |
           mkdocs gh-deploy --config-file mkdocs.yml \
                            --remote-branch gh-pages \
-                           --theme-material \
-                           --markdown-extension=pymdownx.superfences \
-                           --markdown-extension=tables \
-                           --markdown-extension=pymdownx.highlight:
-                               anchor_linenums: true \
-                           --markdown-extension=pymdownx.inlinehilite \
-                           --markdown-extension=pymdownx.snippets
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.ARC_DOCS_TOKEN }}

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,0 +1,38 @@
+name: Deploy docs to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.9'
+
+      - name: Install dependencies
+        run: |
+          pip install mkdocs mkdocs-material
+          pip install markdown-extensions pymdown-extensions
+
+      - name: Deploy docs
+        run: |
+          mkdocs gh-deploy --config-file mkdocs.yml \
+                           --remote-branch gh-pages \
+                           --theme-material \
+                           --markdown-extension=pymdownx.superfences \
+                           --markdown-extension=tables \
+                           --markdown-extension=pymdownx.highlight:
+                               anchor_linenums: true \
+                           --markdown-extension=pymdownx.inlinehilite \
+                           --markdown-extension=pymdownx.snippets
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Ticket Link - [ARC-871](https://sourcefuse.atlassian.net/browse/ARC-871)

I have tested this in my personal repo and this worked  and i have used ARC_DOCS_TOKEN instead of GITHUB_TOKEN because we cant add GITHUB_TOKEN name in secrets


[ARC-871]: https://sourcefuse.atlassian.net/browse/ARC-871?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ