### PR TITLE
added force in gh-deploy and changed name of Token

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -25,7 +25,8 @@ jobs:
           pip install mkdocs-include-markdown-plugin
       - name: Deploy docs
         run: |
-          mkdocs gh-deploy --config-file mkdocs.yml \
+          mkdocs gh-deploy --force \
+                           --config-file mkdocs.yml \
                            --remote-branch gh-pages \
         env:
-          GITHUB_TOKEN: ${{ secrets.ARC_DOCS_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Adding `--force` in gh-deploy

That will do the following:

Clean and build to site directory.
Force push to gh-pages branch, overwriting any changes which were pushed from another build.

Also changed `ARC_DOCS_TOKEN` to `GITHUB_TOKEN `