### PR TITLE
55-add-information-for-github-iam-usage

### DIFF
--- a/docs/arc-iac-docs/.pages.yml
+++ b/docs/arc-iac-docs/.pages.yml
@@ -26,7 +26,9 @@ nav:
           - Security: "arc-iac-docs/modules/terraform-aws-arc-security"
           - Billing: "arc-iac-docs/modules/terraform-aws-arc-billing"
           - Document-DB: "arc-iac-docs/modules/terraform-aws-arc-document-db"
-          - Github IAM: "arc-iac-docs/modules/terraform-aws-arc-github-iam"
+          - Github IAM:
+            - "arc-iac-docs/modules/terraform-aws-arc-github-iam"
+            - Terraform AWS ARC GitHub IAM Module Usage Guide: ".docs/terraform-aws-arc-github-iam-module-usage-guide.md"
           - Backstage:
             - ECS: "arc-iac-docs/modules/arc-backstage-ecs-app"
       - Cloud Native:

--- a/docs/arc-iac-docs/.pages.yml
+++ b/docs/arc-iac-docs/.pages.yml
@@ -28,7 +28,7 @@ nav:
           - Document-DB: "arc-iac-docs/modules/terraform-aws-arc-document-db"
           - Github IAM:
             - "arc-iac-docs/modules/terraform-aws-arc-github-iam"
-            - Terraform AWS ARC GitHub IAM Module Usage Guide: ".docs/terraform-aws-arc-github-iam-module-usage-guide.md"
+            - Terraform AWS ARC GitHub IAM Module Usage Guide: "arc-iac-docs/modules/terraform-aws-arc-github-iam/.docs/terraform-aws-arc-github-iam-module-usage-guide.md"
           - Backstage:
             - ECS: "arc-iac-docs/modules/arc-backstage-ecs-app"
       - Cloud Native:


### PR DESCRIPTION
Adding subpage for github iam docs

Closes: #55 